### PR TITLE
Feat/#24 결제 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 
-	//security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-
 	//mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/interpark/domain/payment/method/controller/PaymentController.java
+++ b/src/main/java/com/interpark/domain/payment/method/controller/PaymentController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.interpark.domain.payment.method.dto.request.PayTicketRequest;
+import com.interpark.domain.payment.method.dto.response.GetPaymentInfoResponse;
 import com.interpark.domain.payment.method.dto.response.GetPaymentMethodListRes;
 import com.interpark.domain.payment.method.service.PaymentService;
 import com.interpark.global.dto.SuccessResponse;
@@ -30,6 +31,7 @@ public class PaymentController {
 
 	@PostMapping
 	public ResponseEntity<SuccessResponse<?>> payTicket(@RequestBody PayTicketRequest payTicketRequest){
-		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+		GetPaymentInfoResponse response = paymentService.getPaymentInfo(payTicketRequest);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE, response));
 	}
 }

--- a/src/main/java/com/interpark/domain/payment/method/controller/PaymentController.java
+++ b/src/main/java/com/interpark/domain/payment/method/controller/PaymentController.java
@@ -1,0 +1,35 @@
+package com.interpark.domain.payment.method.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.interpark.domain.payment.method.dto.request.PayTicketRequest;
+import com.interpark.domain.payment.method.dto.response.GetPaymentMethodListRes;
+import com.interpark.domain.payment.method.service.PaymentService;
+import com.interpark.global.dto.SuccessResponse;
+import com.interpark.global.error.code.SuccessCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tickets/payment")
+public class PaymentController {
+	private final PaymentService paymentService;
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse<?>> getPaymentMethod(){
+		GetPaymentMethodListRes response = paymentService.getPaymentMethod();
+
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, response));
+	}
+
+	@PostMapping
+	public ResponseEntity<SuccessResponse<?>> payTicket(@RequestBody PayTicketRequest payTicketRequest){
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+}

--- a/src/main/java/com/interpark/domain/payment/method/dto/request/PayTicketRequest.java
+++ b/src/main/java/com/interpark/domain/payment/method/dto/request/PayTicketRequest.java
@@ -1,0 +1,19 @@
+package com.interpark.domain.payment.method.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PayTicketRequest(
+	@NotNull(message = "총금액은 필수 입력값입니다")
+	int totalPrice,
+	@NotNull(message = "티켓 개수는 필수 입력값입니다")
+	int ticketCount,
+	@NotNull(message = "티켓 수령 방법은 필수 입력값입니다")
+	String deliveryMethod,
+	@NotNull(message = "예매자 정보는 필수 입력값입니다")
+	UserInfoRequest userInfo,
+	@NotNull(message = "결제수단 정보는 필수 입력값입니다")
+	String paymentMethod
+) {
+}

--- a/src/main/java/com/interpark/domain/payment/method/dto/request/UserInfoRequest.java
+++ b/src/main/java/com/interpark/domain/payment/method/dto/request/UserInfoRequest.java
@@ -1,9 +1,17 @@
 package com.interpark.domain.payment.method.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
 public record UserInfoRequest(
+	@NotNull(message = "예매자의 이름은 필수 입력값입니다")
 	String name,
+	@NotNull(message = "예매자의 생일은 필수 입력값입니다")
 	String birth,
+	@NotNull(message = "예매자의 전화번호는 필수 입력값입니다")
 	String phoneNumber,
+	@NotNull(message = "예매자의 이메일은 필수 입력값입니다")
+	@Email(message = "올바른 이메일 형식이 아닙니다")
 	String email
 ) {
 }

--- a/src/main/java/com/interpark/domain/payment/method/dto/request/UserInfoRequest.java
+++ b/src/main/java/com/interpark/domain/payment/method/dto/request/UserInfoRequest.java
@@ -1,0 +1,9 @@
+package com.interpark.domain.payment.method.dto.request;
+
+public record UserInfoRequest(
+	String name,
+	String birth,
+	String phoneNumber,
+	String email
+) {
+}

--- a/src/main/java/com/interpark/domain/payment/method/dto/response/GetPaymentInfoResponse.java
+++ b/src/main/java/com/interpark/domain/payment/method/dto/response/GetPaymentInfoResponse.java
@@ -1,0 +1,18 @@
+package com.interpark.domain.payment.method.dto.response;
+
+import com.interpark.domain.payment.method.dto.request.PayTicketRequest;
+import com.interpark.domain.payment.method.dto.request.UserInfoRequest;
+
+import jakarta.validation.constraints.NotNull;
+
+public record GetPaymentInfoResponse(
+	int totalPrice,
+	int ticketCount,
+	String deliveryMethod,
+	UserInfoRequest userInfo,
+	String paymentMethod
+) {
+	public static GetPaymentInfoResponse of(PayTicketRequest payTicketRequest) {
+		return new GetPaymentInfoResponse(payTicketRequest.totalPrice(), payTicketRequest.ticketCount(), payTicketRequest.deliveryMethod(), payTicketRequest.userInfo(), payTicketRequest.paymentMethod());
+	}
+}

--- a/src/main/java/com/interpark/domain/payment/method/dto/response/GetPaymentMethodListRes.java
+++ b/src/main/java/com/interpark/domain/payment/method/dto/response/GetPaymentMethodListRes.java
@@ -1,0 +1,11 @@
+package com.interpark.domain.payment.method.dto.response;
+
+import java.util.List;
+
+public record GetPaymentMethodListRes(
+	List<GetPaymentMethodResponse> paymentMethodList
+) {
+	public static GetPaymentMethodListRes of(List<GetPaymentMethodResponse> paymentMethodList) {
+		return new GetPaymentMethodListRes(paymentMethodList);
+	}
+}

--- a/src/main/java/com/interpark/domain/payment/method/dto/response/GetPaymentMethodResponse.java
+++ b/src/main/java/com/interpark/domain/payment/method/dto/response/GetPaymentMethodResponse.java
@@ -1,0 +1,12 @@
+package com.interpark.domain.payment.method.dto.response;
+
+import com.interpark.domain.payment.method.entity.PaymentMethod;
+
+public record GetPaymentMethodResponse(
+	String name,
+	String imageUrl
+) {
+	public static GetPaymentMethodResponse of(PaymentMethod paymentMethod) {
+		return new GetPaymentMethodResponse(paymentMethod.getMethodName(), paymentMethod.getMethodImageUrl());
+	}
+}

--- a/src/main/java/com/interpark/domain/payment/method/repository/PaymentRepository.java
+++ b/src/main/java/com/interpark/domain/payment/method/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.interpark.domain.payment.method.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.interpark.domain.payment.method.entity.PaymentMethod;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<PaymentMethod, Long> {
+}

--- a/src/main/java/com/interpark/domain/payment/method/service/PaymentService.java
+++ b/src/main/java/com/interpark/domain/payment/method/service/PaymentService.java
@@ -1,0 +1,26 @@
+package com.interpark.domain.payment.method.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.interpark.domain.payment.method.dto.response.GetPaymentMethodListRes;
+import com.interpark.domain.payment.method.dto.response.GetPaymentMethodResponse;
+import com.interpark.domain.payment.method.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+	private final PaymentRepository paymentRepository;
+
+	public GetPaymentMethodListRes getPaymentMethod(){
+		List<GetPaymentMethodResponse> getPaymentMethodResponse = paymentRepository.findAll()
+			.stream()
+			.map(GetPaymentMethodResponse::of)
+			.toList();
+		GetPaymentMethodListRes response = GetPaymentMethodListRes.of(getPaymentMethodResponse);
+		return response;
+	}
+}

--- a/src/main/java/com/interpark/domain/payment/method/service/PaymentService.java
+++ b/src/main/java/com/interpark/domain/payment/method/service/PaymentService.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.interpark.domain.payment.method.dto.request.PayTicketRequest;
+import com.interpark.domain.payment.method.dto.response.GetPaymentInfoResponse;
 import com.interpark.domain.payment.method.dto.response.GetPaymentMethodListRes;
 import com.interpark.domain.payment.method.dto.response.GetPaymentMethodResponse;
 import com.interpark.domain.payment.method.repository.PaymentRepository;
@@ -21,6 +23,11 @@ public class PaymentService {
 			.map(GetPaymentMethodResponse::of)
 			.toList();
 		GetPaymentMethodListRes response = GetPaymentMethodListRes.of(getPaymentMethodResponse);
+		return response;
+	}
+
+	public GetPaymentInfoResponse getPaymentInfo(PayTicketRequest request){
+		GetPaymentInfoResponse response = GetPaymentInfoResponse.of(request);
 		return response;
 	}
 }

--- a/src/main/java/com/interpark/global/config/CorsConfig.java
+++ b/src/main/java/com/interpark/global/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.interpark.config;
+package com.interpark.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## 📣 Related Issue

- close #24 

## 📝 Summary

- [ ] 결제 수단 조회 API 구현
- [ ] 결제 API 구현

## 🙏 Question & PR point
- 현재 저희가 구현해야하는 뷰에서 결제한 내역을 불러오는 API는 없어서 이를 DB에 넣어두지 않는 게 맞지 않을까라는 생각이 들어 request의 유효성 검사만 통과했을 시에 바로 성공 응답을 내려주고 있는데 어떻게 생각하시나요

## 📬 Postman

### 결제 API
<img width="620" alt="image" src="https://github.com/user-attachments/assets/5d0f5e56-a8b0-45ac-ab6c-74869bd2ccb3" />

### 결제수단조회 API
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f51d6b95-976e-42e7-89b2-770c840efb27" />
